### PR TITLE
column builder DSL

### DIFF
--- a/examples/table/main.go
+++ b/examples/table/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kolide/osquery-golang"
+	. "github.com/kolide/osquery-golang/sql"
 )
 
 func main() {
@@ -60,12 +61,12 @@ func (f *ExampleTable) TableName() string {
 }
 
 func (f *ExampleTable) Columns() []osquery.ColumnDefinition {
-	return []osquery.ColumnDefinition{
-		osquery.TextColumn("text"),
-		osquery.IntegerColumn("integer"),
-		osquery.BigIntColumn("big_int"),
-		osquery.DoubleColumn("double"),
-	}
+	return ColumnSlice(
+		TextColumn("text"),
+		IntegerColumn("integer"),
+		BigIntColumn("big_int"),
+		DoubleColumn("double"),
+	)
 }
 
 func (f *ExampleTable) Generate(ctx context.Context, queryContext osquery.QueryContext) ([]map[string]string, error) {

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -1,0 +1,42 @@
+package sql
+
+import osquery "github.com/kolide/osquery-golang"
+
+// TextColumn is a helper for defining columns containing strings.
+func TextColumn(name string) osquery.ColumnDefinition {
+	return osquery.ColumnDefinition{
+		Name: name,
+		Type: osquery.ColumnTypeText,
+	}
+}
+
+// IntegerColumn is a helper for defining columns containing integers.
+func IntegerColumn(name string) osquery.ColumnDefinition {
+	return osquery.ColumnDefinition{
+		Name: name,
+		Type: osquery.ColumnTypeInteger,
+	}
+}
+
+// BigIntColumn is a helper for defining columns containing big integers.
+func BigIntColumn(name string) osquery.ColumnDefinition {
+	return osquery.ColumnDefinition{
+		Name: name,
+		Type: osquery.ColumnTypeBigInt,
+	}
+}
+
+// DoubleColumn is a helper for defining columns containing floating point
+// values.
+func DoubleColumn(name string) osquery.ColumnDefinition {
+	return osquery.ColumnDefinition{
+		Name: name,
+		Type: osquery.ColumnTypeDouble,
+	}
+}
+
+// ColumnSlice is a helper that takes an N number of definions and creates an
+// []osquery.ColumnDefinition.
+func ColumnSlice(columns ...osquery.ColumnDefinition) []osquery.ColumnDefinition {
+	return columns
+}

--- a/table.go
+++ b/table.go
@@ -120,39 +120,6 @@ type ColumnDefinition struct {
 	Type ColumnType
 }
 
-// TextColumn is a helper for defining columns containing strings.
-func TextColumn(name string) ColumnDefinition {
-	return ColumnDefinition{
-		Name: name,
-		Type: ColumnTypeText,
-	}
-}
-
-// IntegerColumn is a helper for defining columns containing integers.
-func IntegerColumn(name string) ColumnDefinition {
-	return ColumnDefinition{
-		Name: name,
-		Type: ColumnTypeInteger,
-	}
-}
-
-// BigIntColumn is a helper for defining columns containing big integers.
-func BigIntColumn(name string) ColumnDefinition {
-	return ColumnDefinition{
-		Name: name,
-		Type: ColumnTypeBigInt,
-	}
-}
-
-// DoubleColumn is a helper for defining columns containing floating point
-// values.
-func DoubleColumn(name string) ColumnDefinition {
-	return ColumnDefinition{
-		Name: name,
-		Type: ColumnTypeDouble,
-	}
-}
-
 // ColumnType is a strongly typed representation of the data type string for a
 // column definition. The named constants should be used.
 type ColumnType string


### PR DESCRIPTION
This is a demonstration of an idea I had to simplify writing the `Columns()` method for a table plugin. 

The idea is that the helpers for ColumnDefinition types are moved to a separate package which is safe to import into a table plugin namespace using a `.` import. 

Example: 

```
import (
	"github.com/kolide/osquery-golang"
	. "github.com/kolide/osquery-golang/sql"
)

type ExampleTable struct{}


func (f *ExampleTable) Columns() []osquery.ColumnDefinition {
	return ColumnSlice(
		TextColumn("text"),
		IntegerColumn("integer"),
		BigIntColumn("big_int"),
		DoubleColumn("double"),
	)
}
```