### PR TITLE
Rename the library to osquery-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: gen examples
 gen: ./osquery.thrift
 	rm -rf ./gen
 	mkdir ./gen
-	thrift --gen go:package_prefix=github.com/kolide/osquery-golang/gen/ -out ./gen ./osquery.thrift
+	thrift --gen go:package_prefix=github.com/kolide/osquery-go/gen/ -out ./gen ./osquery.thrift
 	rm -rf gen/osquery/extension-remote gen/osquery/extension_manager-remote
 	gofmt -w ./gen
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# osquery-golang
+# osquery-go
 Thrift bindings for Go programs to interact with osquery

--- a/client.go
+++ b/client.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/kolide/osquery-golang/gen/osquery"
+	"github.com/kolide/osquery-go/gen/osquery"
 	"github.com/pkg/errors"
 
 	"git.apache.org/thrift.git/lib/go/thrift"

--- a/config.go
+++ b/config.go
@@ -3,7 +3,7 @@ package osquery
 import (
 	"context"
 
-	"github.com/kolide/osquery-golang/gen/osquery"
+	"github.com/kolide/osquery-go/gen/osquery"
 )
 
 // ConfigPlugin is the minimum interface required to implement an osquery

--- a/examples/call/main.go
+++ b/examples/call/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/kolide/osquery-golang"
+	"github.com/kolide/osquery-go"
 )
 
 func main() {

--- a/examples/config/main.go
+++ b/examples/config/main.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/kolide/osquery-golang"
+	"github.com/kolide/osquery-go"
 )
 
 func main() {

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/kolide/osquery-golang"
+	"github.com/kolide/osquery-go"
 )
 
 func main() {

--- a/examples/table/main.go
+++ b/examples/table/main.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/kolide/osquery-golang"
+	"github.com/kolide/osquery-go"
 )
 
 func main() {

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/kolide/osquery-golang
+package: github.com/kolide/osquery-go
 import:
 - package: git.apache.org/thrift.git
   version: server_socket_from_addr

--- a/server.go
+++ b/server.go
@@ -8,7 +8,7 @@ import (
 
 	"git.apache.org/thrift.git/lib/go/thrift"
 
-	"github.com/kolide/osquery-golang/gen/osquery"
+	"github.com/kolide/osquery-go/gen/osquery"
 	"github.com/pkg/errors"
 )
 

--- a/table.go
+++ b/table.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/kolide/osquery-golang/gen/osquery"
+	"github.com/kolide/osquery-go/gen/osquery"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
If you want, I cloned it as osquery-go and sed'd the directory to make it compile.