### PR TITLE
add server Run method which calls Start and Shutdown

### DIFF
--- a/examples/config/main.go
+++ b/examples/config/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/kolide/osquery-go"
 )
@@ -24,7 +23,7 @@ sudo ./example_call /var/osquery/osquery.em config example_config genConfig
 		os.Exit(1)
 	}
 
-	serv, err := osquery.NewExtensionManagerServer("example_config", os.Args[1], 1*time.Second)
+	serv, err := osquery.NewExtensionManagerServer("example_config", os.Args[1])
 	if err != nil {
 		fmt.Printf("Error creating extension: %v\n", err)
 		os.Exit(1)

--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/kolide/osquery-go"
 )
@@ -19,7 +18,7 @@ func main() {
 	flag.Int("interval", 0, "")
 	flag.Parse()
 
-	serv, err := osquery.NewExtensionManagerServer("example_logger", *socketPath, 1*time.Second)
+	serv, err := osquery.NewExtensionManagerServer("example_logger", *socketPath)
 	if err != nil {
 		fmt.Printf("Error creating extension: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
After implementing a few plugins I felt that the signal handling and calling Start and Shutdown was a bit repetitive, so I added a `Run() error` method on the server to handle starting and stoping. 

Using Run() also makes the examples a bit more focused on how simple it is to create a plugin.  