### PR TITLE
Update glide files to use standard thrift fork

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,9 +1,8 @@
-hash: 5ce2c973e0be69cd2b70f9012013b3901f729063fe0aa851039153f40045e8a4
-updated: 2017-06-15T18:06:32.80983443-07:00
+hash: f1a4c4e166783b31fcca7b40cb6fbdf79d973fd0c26a54ae479e2e66af866ab9
+updated: 2017-06-22T10:33:47.094547644-04:00
 imports:
 - name: git.apache.org/thrift.git
-  version: 891852bb99ce0e280f55ccdb20c5c4be2d14a2ee
-  repo: git@github.com:kolide/thrift.git
+  version: b8ee72de5bf9318d50846852082325d0f932682b
   subpackages:
   - lib/go/thrift
 - name: github.com/pkg/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,8 +1,10 @@
 package: github.com/kolide/osquery-go
 import:
 - package: git.apache.org/thrift.git
-  version: server_socket_from_addr
-  repo: git@github.com:kolide/thrift.git
+  # We need this commit for the change introducing support for unix domain
+  # server sockets. After the next release, we can use a version range starting
+  # from that release.
+  version: b8ee72de5bf9318d50846852082325d0f932682b
   subpackages:
   - lib/go/thrift
 - package: github.com/pkg/errors


### PR DESCRIPTION
We needed to use a custom fork of thrift for unix domain server socket support.
With that change now merged, we can change back to using the base thrift repo.