### PR TITLE
Expose underlying Thrift client in ExtensionManagerClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,7 +23,7 @@ type ExtensionManager interface {
 
 // ExtensionManagerClient is a wrapper for the osquery Thrift extensions API.
 type ExtensionManagerClient struct {
-	client    osquery.ExtensionManager
+	Client    osquery.ExtensionManager
 	transport thrift.TTransport
 }
 
@@ -57,34 +57,34 @@ func (c *ExtensionManagerClient) Close() {
 
 // Ping requests metadata from the extension manager.
 func (c *ExtensionManagerClient) Ping() (*osquery.ExtensionStatus, error) {
-	return c.client.Ping()
+	return c.Client.Ping()
 }
 
 // Call requests a call to an extension (or core) registry plugin.
 func (c *ExtensionManagerClient) Call(registry, item string, request osquery.ExtensionPluginRequest) (*osquery.ExtensionResponse, error) {
-	return c.client.Call(registry, item, request)
+	return c.Client.Call(registry, item, request)
 }
 
 // Extensions requests the list of active registered extensions.
 func (c *ExtensionManagerClient) Extensions() (osquery.InternalExtensionList, error) {
-	return c.client.Extensions()
+	return c.Client.Extensions()
 }
 
 // RegisterExtension registers the extension plugins with the osquery process.
 func (c *ExtensionManagerClient) RegisterExtension(info *osquery.InternalExtensionInfo, registry osquery.ExtensionRegistry) (*osquery.ExtensionStatus, error) {
-	return c.client.RegisterExtension(info, registry)
+	return c.Client.RegisterExtension(info, registry)
 }
 
 // Options requests the list of bootstrap or configuration options.
 func (c *ExtensionManagerClient) Options() (osquery.InternalOptionList, error) {
-	return c.client.Options()
+	return c.Client.Options()
 }
 
 // Query requests a query to be run and returns the extension response.
 // Consider using the QueryRow or QueryRows helpers for a more friendly
 // interface.
 func (c *ExtensionManagerClient) Query(sql string) (*osquery.ExtensionResponse, error) {
-	return c.client.Query(sql)
+	return c.Client.Query(sql)
 }
 
 // QueryRows is a helper that executes the requested query and returns the
@@ -120,5 +120,5 @@ func (c *ExtensionManagerClient) QueryRow(sql string) (map[string]string, error)
 
 // GetQueryColumns requests the columns returned by the parsed query.
 func (c *ExtensionManagerClient) GetQueryColumns(sql string) (*osquery.ExtensionResponse, error) {
-	return c.client.GetQueryColumns(sql)
+	return c.Client.GetQueryColumns(sql)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestQueryRows(t *testing.T) {
 	mock := &mock.ExtensionManager{}
-	client := &ExtensionManagerClient{client: mock}
+	client := &ExtensionManagerClient{Client: mock}
 
 	// Transport related error
 	mock.QueryFunc = func(sql string) (*osquery.ExtensionResponse, error) {


### PR DESCRIPTION
This is useful for testing or any user that wants finer level control over the
operations being performed with the Thrift client.