### PR TITLE
Using github.com/apache/thrift instead of a git.apache.org one.

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kolide/osquery-go/transport"
 	"github.com/pkg/errors"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 type ExtensionManager interface {

--- a/gen/osquery/osquery-consts.go
+++ b/gen/osquery/osquery-consts.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"reflect"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/gen/osquery/osquery.go
+++ b/gen/osquery/osquery.go
@@ -10,7 +10,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kolide/osquery-go
 
 require (
-	git.apache.org/thrift.git v0.0.0-20180705132951-f12cacf56145
 	github.com/Microsoft/go-winio v0.4.9
+	github.com/apache/thrift v0.12.0
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ git.apache.org/thrift.git v0.0.0-20180705132951-f12cacf56145 h1:eqkP2n4Uh6y/Jjzu
 git.apache.org/thrift.git v0.0.0-20180705132951-f12cacf56145/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/Microsoft/go-winio v0.4.9 h1:3RbgqgGVqmcpbOiwrjbVtDHLlJBGF6aE+yHmNtBNsFQ=
 github.com/Microsoft/go-winio v0.4.9/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
+github.com/apache/thrift v0.12.0 h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=
+github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=

--- a/server.go
+++ b/server.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 
 	"github.com/kolide/osquery-go/gen/osquery"
 	"github.com/kolide/osquery-go/transport"

--- a/server_test.go
+++ b/server_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 
 	"github.com/kolide/osquery-go/gen/osquery"
 	"github.com/kolide/osquery-go/plugin/logger"

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/pkg/errors"
 )
 

--- a/transport/transport_windows.go
+++ b/transport/transport_windows.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Microsoft/go-winio"
 	"github.com/pkg/errors"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // Open opens the named pipe with the provided path and timeout,


### PR DESCRIPTION
github.com/apache/thrift/lib/go is now the official Thrift repository (see https://thrift.apache.org/developers).
git.apache.org location is deprecated and git.apache.org seems to be down for the last few days (see https://status.apache.org/). The git.apache.org downtime is likely accidental, but it's a good enough reason to speed up the migration to a github.com repo.