### PR TITLE
Fix example for table and config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ deps-go: go-mod-check go-mod-download
 deps: deps-go
 
 gen: ./osquery.thrift
-	mkdir ./gen
+	mkdir -p ./gen
 	thrift --gen go:package_prefix=github.com/kolide/osquery-go/gen/ -out ./gen ./osquery.thrift
 	rm -rf gen/osquery/extension-remote gen/osquery/extension_manager-remote
 	gofmt -w ./gen


### PR DESCRIPTION
When running an extension with osqueryi or osqueryd, osquery* binary
spawns the extension process with the following command line args
```
--socket /path/to/socket --timeout 3 --interval 3
```

The example plugins only accept 2 arguments for a valid invocation which
caused the extension to fail when running via --extension flag.

Fix by adding a more formal flag parsing.

Usage:
1. When running the extension as a self managed process:
```
osqueryi
```
and then
```
./extension.ext --socket /var/osquery/osquery.em
```

2. Allowing osquery extension manager to manage the lifecyle of the
extension
```
osqueryi --extension extension.ext
```