### PR TITLE
Adding support for spec generation

### DIFF
--- a/examples/table/main.go
+++ b/examples/table/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -20,17 +21,17 @@ var (
 )
 
 func main() {
-	tbl := table.NewPlugin("example_table", ExampleColumns(), ExampleGenerate, table.WithDescription("A simple example table"))
-
 	flag.Parse()
 
+	tbl := table.NewPlugin("example_table", ExampleColumns(), ExampleGenerate, table.WithDescription("A simple example table"))
+
 	if *spec {
-		specBytes, err := tbl.Spec()
+		tableSpec, err := json.MarshalIndent(tbl.Spec(), "", "  ")
 		if err != nil {
-			log.Fatalf("Error generating spec: %s\n", err)
+			log.Fatalf("Error marshalling spec: %s\n", err)
 		}
 
-		fmt.Printf("%s\n", specBytes)
+		fmt.Printf("%s\n", tableSpec)
 		os.Exit(0)
 	}
 

--- a/examples/table/main.go
+++ b/examples/table/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/osquery/osquery-go"
@@ -14,10 +16,24 @@ var (
 	socket   = flag.String("socket", "", "Path to the extensions UNIX domain socket")
 	timeout  = flag.Int("timeout", 3, "Seconds to wait for autoloaded extensions")
 	interval = flag.Int("interval", 3, "Seconds delay between connectivity checks")
+	spec     = flag.Bool("spec", false, "Don't run as a plugin, instead print the table spec")
 )
 
 func main() {
+	tbl := table.NewPlugin("example_table", ExampleColumns(), ExampleGenerate, table.WithDescription("A simple example table"))
+
 	flag.Parse()
+
+	if *spec {
+		specBytes, err := tbl.Spec()
+		if err != nil {
+			log.Fatalf("Error generating spec: %s\n", err)
+		}
+
+		fmt.Printf("%s\n", specBytes)
+		os.Exit(0)
+	}
+
 	if *socket == "" {
 		log.Fatalln("Missing required --socket argument")
 	}
@@ -38,7 +54,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error creating extension: %s\n", err)
 	}
-	server.RegisterPlugin(table.NewPlugin("example_table", ExampleColumns(), ExampleGenerate))
+	server.RegisterPlugin(tbl)
 	if err := server.Run(); err != nil {
 		log.Fatal(err)
 	}
@@ -46,7 +62,7 @@ func main() {
 
 func ExampleColumns() []table.ColumnDefinition {
 	return []table.ColumnDefinition{
-		table.TextColumn("text"),
+		table.TextColumn("text", table.ColumnDescription("Some text")),
 		table.IntegerColumn("integer"),
 		table.BigIntColumn("big_int"),
 		table.DoubleColumn("double"),

--- a/plugin/table/column.go
+++ b/plugin/table/column.go
@@ -1,0 +1,147 @@
+package table
+
+// ColumnDefinition defines the relevant information for a column in a table
+// plugin. Both values are mandatory. Prefer using the *Column helpers to
+// create ColumnDefinition structs.
+type ColumnDefinition struct {
+	Name        string     `json:"name,omitempty"`
+	Type        ColumnType `json:"type,omitempty"`
+	Description string     `json:"description,omitempty"`
+
+	// Options from https://github.com/osquery/osquery/blob/master/osquery/core/sql/column.h#L37
+	Index      bool `json:"index"`
+	Required   bool `json:"required"`
+	Additional bool `json:"additional"`
+	Optimized  bool `json:"optimized"`
+	Hidden     bool `json:"hidden"`
+}
+
+// ColumnType is a strongly typed representation of the data type string for a
+// column definition. The named constants should be used.
+type ColumnType string
+
+// The following column types are defined in osquery tables.h.
+const (
+	ColumnTypeUnknown        ColumnType = "UNKNOWN"
+	ColumnTypeText                      = "TEXT"
+	ColumnTypeInteger                   = "INTEGER"
+	ColumnTypeBigInt                    = "BIGINT"
+	ColumnTypeUnsignedBigInt            = "UNSIGNED BIGINT"
+	ColumnTypeDouble                    = "DOUBLE"
+	ColumnTypeBlob                      = "BLOB"
+)
+
+type ColumnOpt func(*ColumnDefinition)
+
+// TextColumn is a helper for defining columns containing strings.
+func TextColumn(name string, opts ...ColumnOpt) ColumnDefinition {
+	return NewColumn(name, ColumnTypeText, opts...)
+}
+
+// IntegerColumn is a helper for defining columns containing integers.
+func IntegerColumn(name string, opts ...ColumnOpt) ColumnDefinition {
+	return NewColumn(name, ColumnTypeInteger, opts...)
+}
+
+// BigIntColumn is a helper for defining columns containing big integers.
+func BigIntColumn(name string, opts ...ColumnOpt) ColumnDefinition {
+	return NewColumn(name, ColumnTypeBigInt, opts...)
+}
+
+// DoubleColumn is a helper for defining columns containing floating point
+// values.
+func DoubleColumn(name string, opts ...ColumnOpt) ColumnDefinition {
+	return NewColumn(name, ColumnTypeDouble, opts...)
+}
+
+// NewColumn returns a ColumnDefinition for the specified column.
+func NewColumn(name string, ctype ColumnType, opts ...ColumnOpt) ColumnDefinition {
+	cd := ColumnDefinition{
+		Name: name,
+		Type: ctype,
+	}
+
+	for _, opt := range opts {
+		opt(&cd)
+	}
+
+	return cd
+
+}
+
+// IndexColumn is a functional argument to declare this as an indexed
+// column. Depending on impmelentation, this can significantly change
+// performance.  See osquery source code for more information.
+func IndexColumn() ColumnOpt {
+	return func(cd *ColumnDefinition) {
+		cd.Index = true
+	}
+}
+
+// RequiredColumn is a functional argument that sets this as a
+// required column. sqlite will not process queries, if a required
+// column is missing. See osquery source code for more information.
+func RequiredColumn() ColumnOpt {
+	return func(cd *ColumnDefinition) {
+		cd.Required = true
+	}
+
+}
+
+// AdditionalColumn is a functional argument that sets this as an
+// additional column. See osquery source code for more information.
+func AdditionalColumn() ColumnOpt {
+	return func(cd *ColumnDefinition) {
+		cd.Additional = true
+	}
+
+}
+
+// OptimizedColumn is a functional argument that sets this as an
+// optimized column. See osquery source code for more information.
+func OptimizedColumn() ColumnOpt {
+	return func(cd *ColumnDefinition) {
+		cd.Optimized = true
+	}
+
+}
+
+// HiddenColumn is a functional argument that sets this as an
+// hidden column. This omits it from `select *` queries. See osquery source code for more information.
+func HiddenColumn() ColumnOpt {
+	return func(cd *ColumnDefinition) {
+		cd.Hidden = true
+	}
+
+}
+
+// ColumnDescription sets the column description. This is not
+// currently part of the underlying osquery api, it is here for human
+// consumption. It may become part of osquery spec generation.
+func ColumnDescription(d string) ColumnOpt {
+	return func(cd *ColumnDefinition) {
+		cd.Description = d
+	}
+}
+
+// Options returns the bitmask representation of the boolean column
+// options. This uses the values as encoded in
+// https://github.com/osquery/osquery/blob/master/osquery/core/sql/column.h#L37
+func (c *ColumnDefinition) Options() uint8 {
+	optionsBitmask := uint8(0)
+
+	optionValues := map[uint8]bool{
+		1:  c.Index,
+		2:  c.Required,
+		4:  c.Additional,
+		8:  c.Optimized,
+		16: c.Hidden,
+	}
+
+	for v, b := range optionValues {
+		if b {
+			optionsBitmask = optionsBitmask | v
+		}
+	}
+	return optionsBitmask
+}

--- a/plugin/table/column.go
+++ b/plugin/table/column.go
@@ -4,8 +4,8 @@ package table
 // plugin. Name and Type are mandatory. Prefer using the *Column helpers to
 // create ColumnDefinition structs.
 type ColumnDefinition struct {
-	Name        string     `json:"name,omitempty"`
-	Type        ColumnType `json:"type,omitempty"`
+	Name        string     `json:"name"`
+	Type        ColumnType `json:"type"`
 	Description string     `json:"description,omitempty"`
 	Notes       string     `json:"notes,omitempty"`
 

--- a/plugin/table/column.go
+++ b/plugin/table/column.go
@@ -70,7 +70,7 @@ func NewColumn(name string, ctype ColumnType, opts ...ColumnOpt) ColumnDefinitio
 }
 
 // IndexColumn is a functional argument to declare this as an indexed
-// column. Depending on impmelentation, this can significantly change
+// column. Depending on implementation, this can significantly change
 // performance.  See osquery source code for more information.
 func IndexColumn() ColumnOpt {
 	return func(cd *ColumnDefinition) {

--- a/plugin/table/column.go
+++ b/plugin/table/column.go
@@ -106,7 +106,7 @@ func OptimizedColumn() ColumnOpt {
 
 }
 
-// HiddenColumn is a functional argument that sets this as an
+// HiddenColumn is a functional argument that sets this as a
 // hidden column. This omits it from `select *` queries. See osquery source code for more information.
 func HiddenColumn() ColumnOpt {
 	return func(cd *ColumnDefinition) {

--- a/plugin/table/column.go
+++ b/plugin/table/column.go
@@ -1,5 +1,10 @@
 package table
 
+import (
+	"encoding/json"
+	"strings"
+)
+
 // ColumnDefinition defines the relevant information for a column in a table
 // plugin. Name and Type are mandatory. Prefer using the *Column helpers to
 // create ColumnDefinition structs.
@@ -31,6 +36,17 @@ const (
 	ColumnTypeDouble                    = "DOUBLE"
 	ColumnTypeBlob                      = "BLOB"
 )
+
+// jsonString returns the value used when marshaling ColumnType to JSON
+// (lowercase, spaces as underscores).
+func (ct ColumnType) jsonString() string {
+	return strings.ReplaceAll(strings.ToLower(string(ct)), " ", "_")
+}
+
+// MarshalJSON implements json.Marshaler.
+func (ct ColumnType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ct.jsonString())
+}
 
 type ColumnOpt func(*ColumnDefinition)
 
@@ -94,7 +110,6 @@ func AdditionalColumn() ColumnOpt {
 	return func(cd *ColumnDefinition) {
 		cd.Additional = true
 	}
-
 }
 
 // OptimizedColumn is a functional argument that sets this as an

--- a/plugin/table/column.go
+++ b/plugin/table/column.go
@@ -1,7 +1,7 @@
 package table
 
 // ColumnDefinition defines the relevant information for a column in a table
-// plugin. Both values are mandatory. Prefer using the *Column helpers to
+// plugin. Name and Type are mandatory. Prefer using the *Column helpers to
 // create ColumnDefinition structs.
 type ColumnDefinition struct {
 	Name        string     `json:"name,omitempty"`
@@ -66,7 +66,6 @@ func NewColumn(name string, ctype ColumnType, opts ...ColumnOpt) ColumnDefinitio
 	}
 
 	return cd
-
 }
 
 // IndexColumn is a functional argument to declare this as an indexed
@@ -130,6 +129,7 @@ func ColumnDescription(d string) ColumnOpt {
 func (c *ColumnDefinition) Options() uint8 {
 	optionsBitmask := uint8(0)
 
+	// We can skip the 0: default case, because it's what you get if nothing is set.
 	optionValues := map[uint8]bool{
 		1:  c.Index,
 		2:  c.Required,

--- a/plugin/table/column.go
+++ b/plugin/table/column.go
@@ -7,6 +7,7 @@ type ColumnDefinition struct {
 	Name        string     `json:"name,omitempty"`
 	Type        ColumnType `json:"type,omitempty"`
 	Description string     `json:"description,omitempty"`
+	Notes       string     `json:"notes,omitempty"`
 
 	// Options from https://github.com/osquery/osquery/blob/master/osquery/core/sql/column.h#L37
 	Index      bool `json:"index"`
@@ -111,7 +112,6 @@ func HiddenColumn() ColumnOpt {
 	return func(cd *ColumnDefinition) {
 		cd.Hidden = true
 	}
-
 }
 
 // ColumnDescription sets the column description. This is not

--- a/plugin/table/column_test.go
+++ b/plugin/table/column_test.go
@@ -1,0 +1,30 @@
+package table
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestColumnDefinition_Options(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		in       []ColumnOpt
+		expected uint8
+	}{
+		{
+			in:       []ColumnOpt{},
+			expected: 0,
+		},
+		{
+			in:       []ColumnOpt{IndexColumn(), HiddenColumn()},
+			expected: 17,
+		},
+	}
+
+	for _, tt := range tests {
+		cd := TextColumn("foo", tt.in...)
+		require.Equal(t, tt.expected, cd.Options())
+	}
+}

--- a/plugin/table/column_test.go
+++ b/plugin/table/column_test.go
@@ -34,22 +34,134 @@ func TestColumnType_MarshalJSON(t *testing.T) {
 func TestColumnDefinition_Options(t *testing.T) {
 	t.Parallel()
 
-	var tests = []struct {
+	// Option bitmask values from osquery column.h: Index=1, Required=2, Additional=4, Optimized=8, Hidden=16
+	tests := []struct {
+		name     string
 		in       []ColumnOpt
 		expected uint8
 	}{
 		{
+			name:     "no options",
 			in:       []ColumnOpt{},
 			expected: 0,
 		},
 		{
+			name:     "Index only",
+			in:       []ColumnOpt{IndexColumn()},
+			expected: 1,
+		},
+		{
+			name:     "Required only",
+			in:       []ColumnOpt{RequiredColumn()},
+			expected: 2,
+		},
+		{
+			name:     "Additional only",
+			in:       []ColumnOpt{AdditionalColumn()},
+			expected: 4,
+		},
+		{
+			name:     "Optimized only",
+			in:       []ColumnOpt{OptimizedColumn()},
+			expected: 8,
+		},
+		{
+			name:     "Hidden only",
+			in:       []ColumnOpt{HiddenColumn()},
+			expected: 16,
+		},
+		{
+			name:     "Index and Hidden",
 			in:       []ColumnOpt{IndexColumn(), HiddenColumn()},
 			expected: 17,
+		},
+		{
+			name:     "all options",
+			in:       []ColumnOpt{IndexColumn(), RequiredColumn(), AdditionalColumn(), OptimizedColumn(), HiddenColumn()},
+			expected: 1 + 2 + 4 + 8 + 16,
 		},
 	}
 
 	for _, tt := range tests {
-		cd := TextColumn("foo", tt.in...)
-		require.Equal(t, tt.expected, cd.Options())
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cd := TextColumn("foo", tt.in...)
+			require.Equal(t, tt.expected, cd.Options())
+		})
 	}
+}
+
+func TestColumnOpts_set_fields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("IndexColumn sets Index", func(t *testing.T) {
+		t.Parallel()
+		cd := TextColumn("c", IndexColumn())
+		require.True(t, cd.Index)
+		require.False(t, cd.Required)
+	})
+	t.Run("RequiredColumn sets Required", func(t *testing.T) {
+		t.Parallel()
+		cd := TextColumn("c", RequiredColumn())
+		require.True(t, cd.Required)
+	})
+	t.Run("AdditionalColumn sets Additional", func(t *testing.T) {
+		t.Parallel()
+		cd := TextColumn("c", AdditionalColumn())
+		require.True(t, cd.Additional)
+	})
+	t.Run("OptimizedColumn sets Optimized", func(t *testing.T) {
+		t.Parallel()
+		cd := TextColumn("c", OptimizedColumn())
+		require.True(t, cd.Optimized)
+	})
+	t.Run("HiddenColumn sets Hidden", func(t *testing.T) {
+		t.Parallel()
+		cd := TextColumn("c", HiddenColumn())
+		require.True(t, cd.Hidden)
+	})
+	t.Run("ColumnDescription sets Description", func(t *testing.T) {
+		t.Parallel()
+		cd := TextColumn("c", ColumnDescription("human-readable note"))
+		require.Equal(t, "human-readable note", cd.Description)
+	})
+	t.Run("multiple opts apply in order", func(t *testing.T) {
+		t.Parallel()
+		cd := TextColumn("c", IndexColumn(), ColumnDescription("desc"), RequiredColumn())
+		require.True(t, cd.Index)
+		require.True(t, cd.Required)
+		require.Equal(t, "desc", cd.Description)
+	})
+}
+
+func TestColumn_helpers_produce_correct_type(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		column ColumnDefinition
+		want   ColumnType
+	}{
+		{"TextColumn", TextColumn("x"), ColumnTypeText},
+		{"IntegerColumn", IntegerColumn("x"), ColumnTypeInteger},
+		{"BigIntColumn", BigIntColumn("x"), ColumnTypeBigInt},
+		{"DoubleColumn", DoubleColumn("x"), ColumnTypeDouble},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, tt.column.Type)
+			require.Equal(t, "x", tt.column.Name)
+		})
+	}
+}
+
+func TestNewColumn_applies_opts(t *testing.T) {
+	t.Parallel()
+
+	cd := NewColumn("custom", ColumnTypeBlob, IndexColumn(), ColumnDescription("blob col"))
+	require.Equal(t, "custom", cd.Name)
+	require.Equal(t, ColumnType("BLOB"), cd.Type)
+	require.True(t, cd.Index)
+	require.Equal(t, "blob col", cd.Description)
 }

--- a/plugin/table/column_test.go
+++ b/plugin/table/column_test.go
@@ -1,10 +1,35 @@
 package table
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestColumnType_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ct       ColumnType
+		expected string
+	}{
+		{ColumnTypeUnknown, `"unknown"`},
+		{ColumnTypeText, `"text"`},
+		{ColumnTypeInteger, `"integer"`},
+		{ColumnTypeBigInt, `"bigint"`},
+		{ColumnTypeUnsignedBigInt, `"unsigned_bigint"`},
+		{ColumnTypeDouble, `"double"`},
+		{ColumnTypeBlob, `"blob"`},
+		{ColumnType("CUSTOM TYPE"), `"custom_type"`},
+	}
+
+	for _, tt := range tests {
+		got, err := json.Marshal(tt.ct)
+		require.NoError(t, err)
+		require.Equal(t, tt.expected, string(got))
+	}
+}
 
 func TestColumnDefinition_Options(t *testing.T) {
 	t.Parallel()

--- a/plugin/table/spec.go
+++ b/plugin/table/spec.go
@@ -1,0 +1,30 @@
+package table
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+type osqueryTableSpec struct {
+	Cacheable bool               `json:"cacheable"`
+	Evented   bool               `json:"evented"`
+	Name      string             `json:"name,omitempty"`
+	Url       string             `json:"url,omitempty"`
+	Platforms []string           `json:"platforms,omitempty"`
+	Columns   []ColumnDefinition `json:"columns,omitempty"`
+}
+
+func (t *Plugin) Spec() (string, error) {
+	// FIXME: the columndefinition type is upcased, is that an issue?
+	tableSpec := osqueryTableSpec{
+		Name:    t.name,
+		Columns: t.columns,
+		//Platforms: []string{"FIXME"},
+	}
+	specBytes, err := json.MarshalIndent(tableSpec, "", "  ")
+	if err != nil {
+		return "", errors.Wrap(err, "marshalling")
+	}
+	return string(specBytes), nil
+}

--- a/plugin/table/spec.go
+++ b/plugin/table/spec.go
@@ -10,7 +10,7 @@ type osqueryTableSpec struct {
 	Name        string             `json:"name"`
 	Description string             `json:"description"`
 	Url         string             `json:"url"`
-	Platforms   []string           `json:"platforms"`
+	Platforms   []platformName     `json:"platforms"`
 	Evented     bool               `json:"evented"`
 	Cacheable   bool               `json:"cacheable"`
 	Notes       string             `json:"notes,omitempty"`
@@ -24,7 +24,7 @@ func (t *Plugin) Spec() ([]byte, error) {
 		Name:        t.name,
 		Description: t.description,
 		Url:         t.url,
-		Platforms:   []string{"blar"},
+		Platforms:   t.platforms,
 		Notes:       t.notes,
 		Examples:    t.examples,
 		Columns:     t.columns,

--- a/plugin/table/spec.go
+++ b/plugin/table/spec.go
@@ -15,7 +15,6 @@ type OsqueryTableSpec struct {
 }
 
 func (t *Plugin) Spec() OsqueryTableSpec {
-	// FIXME: the columndefinition type is upcased, is that an issue?
 	return OsqueryTableSpec{
 		Name:        t.name,
 		Description: t.description,

--- a/plugin/table/spec.go
+++ b/plugin/table/spec.go
@@ -1,12 +1,8 @@
 package table
 
-import (
-	"encoding/json"
-
-	"github.com/pkg/errors"
-)
-
-type osqueryTableSpec struct {
+// OsqueryTableSpec is a struct compatible with the osquery spec files. It
+// can be marshalled to json if desired.
+type OsqueryTableSpec struct {
 	Name        string             `json:"name"`
 	Description string             `json:"description"`
 	Url         string             `json:"url"`
@@ -18,9 +14,9 @@ type osqueryTableSpec struct {
 	Columns     []ColumnDefinition `json:"columns"`
 }
 
-func (t *Plugin) Spec() ([]byte, error) {
+func (t *Plugin) Spec() OsqueryTableSpec {
 	// FIXME: the columndefinition type is upcased, is that an issue?
-	tableSpec := osqueryTableSpec{
+	return OsqueryTableSpec{
 		Name:        t.name,
 		Description: t.description,
 		Url:         t.url,
@@ -29,9 +25,4 @@ func (t *Plugin) Spec() ([]byte, error) {
 		Examples:    t.examples,
 		Columns:     t.columns,
 	}
-	specBytes, err := json.MarshalIndent(tableSpec, "", "  ")
-	if err != nil {
-		return nil, errors.Wrap(err, "marshalling")
-	}
-	return specBytes, nil
 }

--- a/plugin/table/spec.go
+++ b/plugin/table/spec.go
@@ -13,8 +13,8 @@ type osqueryTableSpec struct {
 	Platforms   []string           `json:"platforms"`
 	Evented     bool               `json:"evented"`
 	Cacheable   bool               `json:"cacheable"`
-	Notes       string             `json:"notes",omitempty`
-	Examples    []string           `json:"examples",omitempty`
+	Notes       string             `json:"notes,omitempty"`
+	Examples    []string           `json:"examples,omitempty"`
 	Columns     []ColumnDefinition `json:"columns"`
 }
 

--- a/plugin/table/spec.go
+++ b/plugin/table/spec.go
@@ -7,24 +7,31 @@ import (
 )
 
 type osqueryTableSpec struct {
-	Cacheable bool               `json:"cacheable"`
-	Evented   bool               `json:"evented"`
-	Name      string             `json:"name,omitempty"`
-	Url       string             `json:"url,omitempty"`
-	Platforms []string           `json:"platforms,omitempty"`
-	Columns   []ColumnDefinition `json:"columns,omitempty"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Url         string             `json:"url"`
+	Platforms   []string           `json:"platforms"`
+	Evented     bool               `json:"evented"`
+	Cacheable   bool               `json:"cacheable"`
+	Notes       string             `json:"notes",omitempty`
+	Examples    []string           `json:"examples",omitempty`
+	Columns     []ColumnDefinition `json:"columns"`
 }
 
-func (t *Plugin) Spec() (string, error) {
+func (t *Plugin) Spec() ([]byte, error) {
 	// FIXME: the columndefinition type is upcased, is that an issue?
 	tableSpec := osqueryTableSpec{
-		Name:    t.name,
-		Columns: t.columns,
-		//Platforms: []string{"FIXME"},
+		Name:        t.name,
+		Description: t.description,
+		Url:         t.url,
+		Platforms:   []string{"blar"},
+		Notes:       t.notes,
+		Examples:    t.examples,
+		Columns:     t.columns,
 	}
 	specBytes, err := json.MarshalIndent(tableSpec, "", "  ")
 	if err != nil {
-		return "", errors.Wrap(err, "marshalling")
+		return nil, errors.Wrap(err, "marshalling")
 	}
-	return string(specBytes), nil
+	return specBytes, nil
 }

--- a/plugin/table/spec_test.go
+++ b/plugin/table/spec_test.go
@@ -1,0 +1,60 @@
+package table
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTable_Spec(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		name     string
+		columns  []ColumnDefinition
+		expected string
+	}{
+		{
+			name:    "simple",
+			columns: []ColumnDefinition{TextColumn("simple_text")},
+			expected: `
+{
+  "name": "simple",
+  "cacheable": false,
+  "evented": false,
+  "columns":[
+    { "name": "simple_text", "type": "TEXT", "index": false, "required": false, "additional": false, "optimized": false, "hidden": false }
+  ]
+}`,
+		},
+	}
+
+	mockGenerate := func(_ context.Context, _ QueryContext) ([]map[string]string, error) { return nil, nil }
+
+	for _, tt := range tests {
+		testTable := NewPlugin(tt.name, tt.columns, mockGenerate)
+		generatedSpec, err := testTable.Spec()
+		require.NoError(t, err, "generating spec for %s", tt.name)
+		helperJSONEqVal(t, tt.expected, generatedSpec, "spec for %s", tt.name)
+	}
+}
+
+func helperJSONEqVal(t *testing.T, expected string, actual string, msgAndArgs ...interface{}) {
+	var expectedJSONAsInterface, actualJSONAsInterface interface{}
+
+	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {
+		require.Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)
+		return
+	}
+
+	if err := json.Unmarshal([]byte(actual), &actualJSONAsInterface); err != nil {
+		require.Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
+		return
+	}
+
+	require.EqualValues(t, expectedJSONAsInterface, actualJSONAsInterface, msgAndArgs...)
+	return
+}

--- a/plugin/table/spec_test.go
+++ b/plugin/table/spec_test.go
@@ -3,7 +3,6 @@ package table
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,25 +39,11 @@ func TestTable_Spec(t *testing.T) {
 	for _, tt := range tests {
 		testTable := NewPlugin(tt.name, tt.columns, mockGenerate)
 		testTable.platforms = []platformName{DarwinPlatform}
-		generatedSpec, err := testTable.Spec()
-		require.NoError(t, err, "generating spec for %s", tt.name)
-		helperJSONEqVal(t, tt.expected, generatedSpec, "spec for %s", tt.name)
+		generatedSpec := testTable.Spec()
+
+		var expectedSpec OsqueryTableSpec
+		require.NoError(t, json.Unmarshal([]byte(tt.expected), &expectedSpec))
+
+		require.EqualValues(t, expectedSpec, generatedSpec, "spec for %s", tt.name)
 	}
-}
-
-func helperJSONEqVal(t *testing.T, expected string, actual []byte, msgAndArgs ...interface{}) {
-	var expectedJSONAsInterface, actualJSONAsInterface interface{}
-
-	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {
-		require.Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)
-		return
-	}
-
-	if err := json.Unmarshal(actual, &actualJSONAsInterface); err != nil {
-		require.Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
-		return
-	}
-
-	require.EqualValues(t, expectedJSONAsInterface, actualJSONAsInterface, msgAndArgs...)
-	return
 }

--- a/plugin/table/spec_test.go
+++ b/plugin/table/spec_test.go
@@ -29,7 +29,8 @@ func TestTable_Spec(t *testing.T) {
     { "name": "simple_text", "type": "TEXT", "index": false, "required": false, "additional": false, "optimized": false, "hidden": false }
   ],
   "description": "",
-  "url": ""
+  "url": "",
+  "platforms": ["darwin"]
 }`,
 		},
 	}
@@ -38,6 +39,7 @@ func TestTable_Spec(t *testing.T) {
 
 	for _, tt := range tests {
 		testTable := NewPlugin(tt.name, tt.columns, mockGenerate)
+		testTable.platforms = []platformName{DarwinPlatform}
 		generatedSpec, err := testTable.Spec()
 		require.NoError(t, err, "generating spec for %s", tt.name)
 		helperJSONEqVal(t, tt.expected, generatedSpec, "spec for %s", tt.name)

--- a/plugin/table/spec_test.go
+++ b/plugin/table/spec_test.go
@@ -11,20 +11,21 @@ import (
 func TestTable_Spec(t *testing.T) {
 	t.Parallel()
 
-	var tests = []struct {
+	mockGenerate := func(_ context.Context, _ QueryContext) ([]map[string]string, error) { return nil, nil }
+
+	tests := []struct {
 		name     string
-		columns  []ColumnDefinition
+		plugin   *Plugin
 		expected string
 	}{
 		{
-			name:    "simple",
-			columns: []ColumnDefinition{TextColumn("simple_text")},
-			expected: `
-{
+			name:   "single text column",
+			plugin: NewPlugin("simple", []ColumnDefinition{TextColumn("simple_text")}, mockGenerate),
+			expected: `{
   "name": "simple",
   "cacheable": false,
   "evented": false,
-  "columns":[
+  "columns": [
     { "name": "simple_text", "type": "TEXT", "index": false, "required": false, "additional": false, "optimized": false, "hidden": false }
   ],
   "description": "",
@@ -32,18 +33,110 @@ func TestTable_Spec(t *testing.T) {
   "platforms": ["darwin"]
 }`,
 		},
+		{
+			name: "multiple columns with mixed types",
+			plugin: NewPlugin("mixed", []ColumnDefinition{
+				TextColumn("name"),
+				IntegerColumn("pid"),
+				BigIntColumn("size"),
+				DoubleColumn("score"),
+			}, mockGenerate),
+			expected: `{
+  "name": "mixed",
+  "cacheable": false,
+  "evented": false,
+  "columns": [
+    { "name": "name", "type": "TEXT", "index": false, "required": false, "additional": false, "optimized": false, "hidden": false },
+    { "name": "pid", "type": "INTEGER", "index": false, "required": false, "additional": false, "optimized": false, "hidden": false },
+    { "name": "size", "type": "BIGINT", "index": false, "required": false, "additional": false, "optimized": false, "hidden": false },
+    { "name": "score", "type": "DOUBLE", "index": false, "required": false, "additional": false, "optimized": false, "hidden": false }
+  ],
+  "description": "",
+  "url": "",
+  "platforms": ["darwin"]
+}`,
+		},
+		{
+			name: "columns with options",
+			plugin: NewPlugin("opts", []ColumnDefinition{
+				TextColumn("key", IndexColumn(), RequiredColumn()),
+				IntegerColumn("count", HiddenColumn()),
+			}, mockGenerate),
+			expected: `{
+  "name": "opts",
+  "cacheable": false,
+  "evented": false,
+  "columns": [
+    { "name": "key", "type": "TEXT", "index": true, "required": true, "additional": false, "optimized": false, "hidden": false },
+    { "name": "count", "type": "INTEGER", "index": false, "required": false, "additional": false, "optimized": false, "hidden": true }
+  ],
+  "description": "",
+  "url": "",
+  "platforms": ["darwin"]
+}`,
+		},
+		{
+			name: "plugin with description, url, notes, examples, platforms",
+			plugin: NewPlugin("full", []ColumnDefinition{TextColumn("id")}, mockGenerate,
+				WithDescription("Table description"),
+				WithURL("https://osquery.io/schema"),
+				WithNotes("Some notes"),
+				WithExample("SELECT * FROM full"),
+				WithPlatforms(DarwinPlatform, LinuxPlatform),
+			),
+			expected: `{
+  "name": "full",
+  "cacheable": false,
+  "evented": false,
+  "columns": [
+    { "name": "id", "type": "TEXT", "index": false, "required": false, "additional": false, "optimized": false, "hidden": false }
+  ],
+  "description": "Table description",
+  "url": "https://osquery.io/schema",
+  "notes": "Some notes",
+  "examples": ["SELECT * FROM full"],
+  "platforms": ["darwin", "linux"]
+}`,
+		},
 	}
-
-	mockGenerate := func(_ context.Context, _ QueryContext) ([]map[string]string, error) { return nil, nil }
 
 	for _, tt := range tests {
-		testTable := NewPlugin(tt.name, tt.columns, mockGenerate)
-		testTable.platforms = []platformName{DarwinPlatform}
-		generatedSpec := testTable.Spec()
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if len(tt.plugin.platforms) == 0 {
+				tt.plugin.platforms = []platformName{DarwinPlatform}
+			}
+			generatedSpec := tt.plugin.Spec()
 
-		var expectedSpec OsqueryTableSpec
-		require.NoError(t, json.Unmarshal([]byte(tt.expected), &expectedSpec))
+			var expectedSpec OsqueryTableSpec
+			require.NoError(t, json.Unmarshal([]byte(tt.expected), &expectedSpec))
 
-		require.EqualValues(t, expectedSpec, generatedSpec, "spec for %s", tt.name)
+			require.EqualValues(t, expectedSpec, generatedSpec, "spec for %s", tt.name)
+		})
 	}
+}
+
+func TestTable_Spec_marshal_json_column_type_format(t *testing.T) {
+	t.Parallel()
+
+	// ColumnType should marshal to JSON as lowercase with underscores (e.g. "unsigned_bigint")
+	plugin := NewPlugin("t", []ColumnDefinition{
+		TextColumn("a"),
+		NewColumn("b", ColumnTypeUnsignedBigInt),
+	}, func(_ context.Context, _ QueryContext) ([]map[string]string, error) { return nil, nil })
+	spec := plugin.Spec()
+
+	data, err := json.Marshal(spec)
+	require.NoError(t, err)
+
+	var decoded struct {
+		Columns []struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		} `json:"columns"`
+	}
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Len(t, decoded.Columns, 2)
+	require.Equal(t, "text", decoded.Columns[0].Type)
+	require.Equal(t, "unsigned_bigint", decoded.Columns[1].Type)
 }

--- a/plugin/table/spec_test.go
+++ b/plugin/table/spec_test.go
@@ -27,7 +27,9 @@ func TestTable_Spec(t *testing.T) {
   "evented": false,
   "columns":[
     { "name": "simple_text", "type": "TEXT", "index": false, "required": false, "additional": false, "optimized": false, "hidden": false }
-  ]
+  ],
+  "description": "",
+  "url": ""
 }`,
 		},
 	}
@@ -42,7 +44,7 @@ func TestTable_Spec(t *testing.T) {
 	}
 }
 
-func helperJSONEqVal(t *testing.T, expected string, actual string, msgAndArgs ...interface{}) {
+func helperJSONEqVal(t *testing.T, expected string, actual []byte, msgAndArgs ...interface{}) {
 	var expectedJSONAsInterface, actualJSONAsInterface interface{}
 
 	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {
@@ -50,7 +52,7 @@ func helperJSONEqVal(t *testing.T, expected string, actual string, msgAndArgs ..
 		return
 	}
 
-	if err := json.Unmarshal([]byte(actual), &actualJSONAsInterface); err != nil {
+	if err := json.Unmarshal(actual, &actualJSONAsInterface); err != nil {
 		require.Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
 		return
 	}

--- a/plugin/table/table.go
+++ b/plugin/table/table.go
@@ -18,17 +18,54 @@ import (
 type GenerateFunc func(ctx context.Context, queryContext QueryContext) ([]map[string]string, error)
 
 type Plugin struct {
-	name     string
-	columns  []ColumnDefinition
-	generate GenerateFunc
+	name        string
+	columns     []ColumnDefinition
+	generate    GenerateFunc
+	description string
+	url         string
+	notes       string
+	examples    []string
 }
 
-func NewPlugin(name string, columns []ColumnDefinition, gen GenerateFunc) *Plugin {
-	return &Plugin{
+type TableOpt func(*Plugin)
+
+func WithDescription(description string) TableOpt {
+	return func(tbl *Plugin) {
+		tbl.description = description
+	}
+}
+
+func WithURL(url string) TableOpt {
+	return func(tbl *Plugin) {
+		tbl.url = url
+	}
+}
+
+func WithNotes(notes string) TableOpt {
+	return func(tbl *Plugin) {
+		tbl.notes = notes
+	}
+}
+
+func WithExample(example string) TableOpt {
+	return func(tbl *Plugin) {
+		tbl.examples = append(tbl.examples, example)
+	}
+}
+
+func NewPlugin(name string, columns []ColumnDefinition, gen GenerateFunc, opts ...TableOpt) *Plugin {
+	tbl := &Plugin{
 		name:     name,
 		columns:  columns,
 		generate: gen,
 	}
+
+	for _, opt := range opts {
+		opt(tbl)
+	}
+
+	return tbl
+
 }
 
 func (t *Plugin) Name() string {
@@ -98,7 +135,6 @@ func (t *Plugin) Call(ctx context.Context, request osquery.ExtensionPluginReques
 			},
 		}
 	}
-
 }
 
 func (t *Plugin) Ping() osquery.ExtensionStatus {
@@ -133,7 +169,7 @@ type Constraint struct {
 // Operator is an enum of the osquery operators.
 type Operator int
 
-// The following operators are dfined in osquery tables.h.
+// The following operators are defined in osquery tables.h.
 const (
 	OperatorEquals              Operator = 2
 	OperatorGreaterThan                  = 4
@@ -145,6 +181,7 @@ const (
 	OperatorGlob                         = 66
 	OperatorRegexp                       = 67
 	OperatorUnique                       = 1
+	OperatorIn                           = 3
 )
 
 // The following types and functions exist for parsing of the queryContext

--- a/plugin/table/table.go
+++ b/plugin/table/table.go
@@ -31,30 +31,37 @@ type Plugin struct {
 
 type TableOpt func(*Plugin)
 
+// WithDescription sets the informational table description that will be used if table specs are generated
 func WithDescription(description string) TableOpt {
 	return func(tbl *Plugin) {
 		tbl.description = description
 	}
 }
 
+// WithURL sets the informational table URL that will be used if table specs are generated
 func WithURL(url string) TableOpt {
 	return func(tbl *Plugin) {
 		tbl.url = url
 	}
 }
 
+// WithNotes sets the informational table notes that will be used if table specs are generated
 func WithNotes(notes string) TableOpt {
 	return func(tbl *Plugin) {
 		tbl.notes = notes
 	}
 }
 
+// WithExample adds an informational example that will be used if table specs are generated.
+// Can be used more than once.
 func WithExample(example string) TableOpt {
 	return func(tbl *Plugin) {
 		tbl.examples = append(tbl.examples, example)
 	}
 }
 
+// WithPlatform overrides the default of runtime.GOOS with a list of supported platforms. This
+// is used by the table spec generation.
 func WithPlatforms(platforms ...platformName) TableOpt {
 	return func(tbl *Plugin) {
 		tbl.platforms = platforms

--- a/plugin/table/table.go
+++ b/plugin/table/table.go
@@ -87,7 +87,6 @@ func NewPlugin(name string, columns []ColumnDefinition, gen GenerateFunc, opts .
 	}
 
 	return tbl
-
 }
 
 func (t *Plugin) Name() string {

--- a/plugin/table/table.go
+++ b/plugin/table/table.go
@@ -4,6 +4,7 @@ package table
 import (
 	"context"
 	"encoding/json"
+	"runtime"
 	"strconv"
 
 	"github.com/osquery/osquery-go/gen/osquery"
@@ -25,6 +26,7 @@ type Plugin struct {
 	url         string
 	notes       string
 	examples    []string
+	platforms   []platformName
 }
 
 type TableOpt func(*Plugin)
@@ -62,6 +64,21 @@ func NewPlugin(name string, columns []ColumnDefinition, gen GenerateFunc, opts .
 
 	for _, opt := range opts {
 		opt(tbl)
+	}
+
+	// If the table platform isn't set, use runtime.GOOS to determine it
+	if len(tbl.platforms) == 0 {
+		switch runtime.GOOS {
+		case "darwin":
+			tbl.platforms = []platformName{DarwinPlatform}
+		case "windows":
+			tbl.platforms = []platformName{WindowsPlatform}
+		case "linux":
+			tbl.platforms = []platformName{LinuxPlatform}
+		default:
+			// Historic function signature has no error, so there's not much to do
+			// for an unknown platform.
+		}
 	}
 
 	return tbl
@@ -165,6 +182,14 @@ type Constraint struct {
 	Operator   Operator
 	Expression string
 }
+
+type platformName string
+
+const (
+	DarwinPlatform  platformName = "darwin"
+	WindowsPlatform platformName = "windows"
+	LinuxPlatform   platformName = "linux"
+)
 
 // Operator is an enum of the osquery operators.
 type Operator int

--- a/plugin/table/table.go
+++ b/plugin/table/table.go
@@ -107,59 +107,6 @@ func (t *Plugin) Ping() osquery.ExtensionStatus {
 
 func (t *Plugin) Shutdown() {}
 
-// ColumnDefinition defines the relevant information for a column in a table
-// plugin. Both values are mandatory. Prefer using the *Column helpers to
-// create ColumnDefinition structs.
-type ColumnDefinition struct {
-	Name string
-	Type ColumnType
-}
-
-// TextColumn is a helper for defining columns containing strings.
-func TextColumn(name string) ColumnDefinition {
-	return ColumnDefinition{
-		Name: name,
-		Type: ColumnTypeText,
-	}
-}
-
-// IntegerColumn is a helper for defining columns containing integers.
-func IntegerColumn(name string) ColumnDefinition {
-	return ColumnDefinition{
-		Name: name,
-		Type: ColumnTypeInteger,
-	}
-}
-
-// BigIntColumn is a helper for defining columns containing big integers.
-func BigIntColumn(name string) ColumnDefinition {
-	return ColumnDefinition{
-		Name: name,
-		Type: ColumnTypeBigInt,
-	}
-}
-
-// DoubleColumn is a helper for defining columns containing floating point
-// values.
-func DoubleColumn(name string) ColumnDefinition {
-	return ColumnDefinition{
-		Name: name,
-		Type: ColumnTypeDouble,
-	}
-}
-
-// ColumnType is a strongly typed representation of the data type string for a
-// column definition. The named constants should be used.
-type ColumnType string
-
-// The following column types are defined in osquery tables.h.
-const (
-	ColumnTypeText    ColumnType = "TEXT"
-	ColumnTypeInteger            = "INTEGER"
-	ColumnTypeBigInt             = "BIGINT"
-	ColumnTypeDouble             = "DOUBLE"
-)
-
 // QueryContext contains the constraints from the WHERE clause of the query,
 // that can optionally be used to optimize the table generation. Note that the
 // osquery SQLite engine will perform the filtering with these constraints, so

--- a/plugin/table/table.go
+++ b/plugin/table/table.go
@@ -55,6 +55,11 @@ func WithExample(example string) TableOpt {
 	}
 }
 
+func WithPlatforms(platforms ...platformName) TableOpt {
+	return func(tbl *Plugin) {
+		tbl.platforms = platforms
+	}
+}
 func NewPlugin(name string, columns []ColumnDefinition, gen GenerateFunc, opts ...TableOpt) *Plugin {
 	tbl := &Plugin{
 		name:     name,

--- a/plugin/table/table.go
+++ b/plugin/table/table.go
@@ -46,7 +46,7 @@ func (t *Plugin) Routes() osquery.ExtensionPluginResponse {
 			"id":   "column",
 			"name": col.Name,
 			"type": string(col.Type),
-			"op":   "0",
+			"op":   strconv.FormatUint(uint64(col.Options()), 10),
 		})
 	}
 	return routes


### PR DESCRIPTION
## Why

I keep wanting to generate table specs from plugins. And so, I've revisited some work I started 6+ years ago.

## Description

1. Pulls column related stuff out of `table.go` into `column.go`
2. Adds Function Arguments to a lot of constructors
3. Adds arguments for things like "description", "notes", "examples"
4. Updated the table example to dump the spec

Caveats:
- Some of the table and column options may not be supported by osquery -- the underlying thrift protocol doesn't include them. But since some table implementations do use them, I included them for spec generation.
- I tried to follow existing idioms. Some are kinda gnarly

Closes: #77 
Closes: #78 