### PR TITLE
Bug Fix: Thread Leak in client.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -70,6 +70,7 @@ func NewClient(path string, socketOpenTimeout time.Duration, opts ...ClientOptio
 			return nil, err
 		}
 
+		c.transport = trans
 		c.client = osquery.NewExtensionManagerClientFactory(
 			trans,
 			thrift.NewTBinaryProtocolFactoryDefault(),


### PR DESCRIPTION
# Description

We (Elastic) had a customer report excessive resource usage from osqueryd.exe after a recent update of Elastic's osquerybeat.

We did some research, and consulting with Claude a bit, and were able to identify a thread leak in osquery-go.  When a program creates a new `NewExtensionManagerClient` using the go bindings, `trans` is created and passed to the factory, but is never assigned to assigned to `c.transport`.  Later, when the client is closed, the client does not close transport, so it is left dangling.

When the calling program exits, the threads are cleaned up in osqueryd.  However, if the calling program never exits, the threads stay alive in osqueryd in a waiting state indefinitely. 

In our case, Osquerybeat was creating a client once every 30s an issuing a query, then closing the client, but staying alive.  So the customer saw unrestrained growth of threads in osqueryd.

# Solution
The fix is simple, just add the line to assign the transport variable, and it will be closed properly when the client is closed.


# Offending Code
https://github.com/osquery/osquery-go/blob/f77b3a1e15ccfb7ffebe1783df9b6c7430b30dc8/client.go#L51-L88

# Proof of Concept

I had Claude help me make a proof of concept that exercises this bug
<details>
<summary>
Expand: POC code to trigger the bug
</summary>

```go
package main

import (
	"context"
	"flag"
	"fmt"
	"log"
	"os"
	"os/signal"
	"time"

	osquery "github.com/osquery/osquery-go"
)

func main() {
	socketPath := flag.String("socket", "", "path to osqueryd's extension manager socket/pipe")
	interval := flag.Duration("interval", 1*time.Second, "delay between connections")
	count := flag.Int("count", 50, "number of connections to open")
	flag.Parse()

	if *socketPath == "" {
		fmt.Fprintln(os.Stderr, "error: --socket is required")
		flag.Usage()
		os.Exit(1)
	}

	if *count < 0 {
		fmt.Fprintln(os.Stderr, "error: --count must be non-negative")
		flag.Usage()
		os.Exit(1)
	}

	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
	defer stop()

	log.Printf("Target socket : %s", *socketPath)
	log.Printf("Interval      : %s", *interval)
	log.Printf("Max connections: %d", *count)
	log.Println("Watch osqueryd's thread count while this runs.")
	log.Println("Press Ctrl+C to stop.")
	fmt.Println()

	client_count := 0
	for {
		if client_count >= *count {
			log.Printf("Reached max connections (%d). Stopping.", *count)
			break
		}

		// Open a new client
		client, err := osquery.NewClient(*socketPath, 5*time.Second)
		if err != nil {
			log.Printf("[%d] connect error: %v", client_count, err)
			time.Sleep(*interval)
			continue
		}

		client_count++
		fmt.Printf("Opened client #%d\n", client_count)

		// Send a lightweight RPC so the server-side thread processes at least
		// one request (this is what makes it block on the *next* read forever).
		status, err := client.PingContext(ctx)
		if err != nil {
			log.Printf("ping error from client #%d: %v", client_count, err)
		} else {
			log.Printf("ping OK from client #%d (code=%d, msg=%q)", client_count, status.GetCode(), status.GetMessage())
		}

		// Close() should clean up the server-side thread, but with the bug it doesn't.
		log.Printf("Closing client #%d", client_count)
		client.Close()

		// Brief pause to make thread growth easy to observe.
		select {
		case <-ctx.Done():
			log.Printf("Interrupted after %d connections.", client_count)
			return
		case <-time.After(*interval):
		}
	}

	// Keep the process alive so the user can inspect osqueryd.
	log.Println("Holding process open. Press Ctrl+C to exit.")
	<-ctx.Done()
	log.Println("Done.")
}
```
</details>

1. Start osqueryd in daemon mode
```bash
osqueryd.exe -D --allow_unsafe
```

2. Create a folder and setup the poc code
```bash
mkdir C:\tmp\leak_poc
cd C:\tmp\leak_poc
<write main.go here>
go mod init leak_poc
go mod tidy
```

3. Run the POC and observe osqueryd's thread count
```bash
go run . --socket "\\.\pipe\osquery.em" --interval .25s --count 500
```
<img width="1042" height="608" alt="image" src="https://github.com/user-attachments/assets/7d5364af-6b9e-4a59-bd07-492f41bd35cb" />
