### PR TITLE
Some general fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,4 +19,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.21
+go 1.26

--- a/plugin/table/column.go
+++ b/plugin/table/column.go
@@ -29,12 +29,12 @@ type ColumnType string
 // The following column types are defined in osquery tables.h.
 const (
 	ColumnTypeUnknown        ColumnType = "UNKNOWN"
-	ColumnTypeText                      = "TEXT"
-	ColumnTypeInteger                   = "INTEGER"
-	ColumnTypeBigInt                    = "BIGINT"
-	ColumnTypeUnsignedBigInt            = "UNSIGNED BIGINT"
-	ColumnTypeDouble                    = "DOUBLE"
-	ColumnTypeBlob                      = "BLOB"
+	ColumnTypeText           ColumnType = "TEXT"
+	ColumnTypeInteger        ColumnType = "INTEGER"
+	ColumnTypeBigInt         ColumnType = "BIGINT"
+	ColumnTypeUnsignedBigInt ColumnType = "UNSIGNED BIGINT"
+	ColumnTypeDouble         ColumnType = "DOUBLE"
+	ColumnTypeBlob           ColumnType = "BLOB"
 )
 
 // jsonString returns the value used when marshaling ColumnType to JSON

--- a/plugin/table/spec_test.go
+++ b/plugin/table/spec_test.go
@@ -19,8 +19,10 @@ func TestTable_Spec(t *testing.T) {
 		expected string
 	}{
 		{
-			name:   "single text column",
-			plugin: NewPlugin("simple", []ColumnDefinition{TextColumn("simple_text")}, mockGenerate),
+			name: "single text column",
+			plugin: NewPlugin("simple", []ColumnDefinition{TextColumn("simple_text")}, mockGenerate,
+				WithPlatforms(DarwinPlatform),
+			),
 			expected: `{
   "name": "simple",
   "cacheable": false,
@@ -40,7 +42,9 @@ func TestTable_Spec(t *testing.T) {
 				IntegerColumn("pid"),
 				BigIntColumn("size"),
 				DoubleColumn("score"),
-			}, mockGenerate),
+			}, mockGenerate,
+				WithPlatforms(DarwinPlatform),
+			),
 			expected: `{
   "name": "mixed",
   "cacheable": false,
@@ -61,7 +65,9 @@ func TestTable_Spec(t *testing.T) {
 			plugin: NewPlugin("opts", []ColumnDefinition{
 				TextColumn("key", IndexColumn(), RequiredColumn()),
 				IntegerColumn("count", HiddenColumn()),
-			}, mockGenerate),
+			}, mockGenerate,
+				WithPlatforms(DarwinPlatform),
+			),
 			expected: `{
   "name": "opts",
   "cacheable": false,
@@ -103,9 +109,6 @@ func TestTable_Spec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if len(tt.plugin.platforms) == 0 {
-				tt.plugin.platforms = []platformName{DarwinPlatform}
-			}
 			generatedSpec := tt.plugin.Spec()
 
 			var expectedSpec OsqueryTableSpec


### PR DESCRIPTION
go.mod:
- Bump golang version to 1.2.6. Behavior of loops changed in 1.22. We could add tt := tt above run in spec_test instead of bumping golang version. https://go.dev/blog/loopvar-preview

column.go:
- Explicitly set types on columns https://staticcheck.dev/docs/checks#SA9004

spec_test.go:
- Explicitly set darwin in each test. Some test environments may have a GOOS defined and may cause flakey tests. We are already defaulting to darwin below, so just explicitly set in the test.