### PR TITLE
add option to allow for buffered transport

### DIFF
--- a/server.go
+++ b/server.go
@@ -61,6 +61,7 @@ type ExtensionManagerServer struct {
 	registry                   map[string](map[string]OsqueryPlugin)
 	server                     thrift.TServer
 	transport                  thrift.TServerTransport
+	transportFactory           thrift.TTransportFactory
 	timeout                    time.Duration
 	pingInterval               time.Duration // How often to ping osquery server
 	mutex                      sync.Mutex
@@ -114,6 +115,19 @@ func ServerConnectivityCheckInterval(interval time.Duration) ServerOption {
 func WithClient(client ExtensionManager) ServerOption {
 	return func(s *ExtensionManagerServer) {
 		s.serverClient = client
+	}
+}
+
+// WithTransportFactory sets the thrift transport factory used to wrap the
+// server's input and output transports. By default the server uses an
+// unbuffered (identity) transport factory, which causes the Thrift binary
+// protocol to issue one write syscall per primitive written. Passing a
+// buffering factory such as thrift.NewTBufferedTransportFactory batches those
+// writes until the generated processor flushes at each response boundary,
+// which can dramatically reduce syscall overhead for large result sets.
+func WithTransportFactory(f thrift.TTransportFactory) ServerOption {
+	return func(s *ExtensionManagerServer) {
+		s.transportFactory = f
 	}
 }
 
@@ -232,7 +246,14 @@ func (s *ExtensionManagerServer) Start() error {
 			return openError
 		}
 
-		s.server = thrift.NewTSimpleServer2(processor, s.transport)
+		tf := s.transportFactory
+		if tf == nil {
+			// Preserve the historical unbuffered default.
+			tf = thrift.NewTTransportFactory()
+		}
+		s.server = thrift.NewTSimpleServer4(
+			processor, s.transport, tf, thrift.NewTBinaryProtocolFactoryConf(nil),
+		)
 		server = s.server
 
 		s.started = true

--- a/server_test.go
+++ b/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"runtime/pprof"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -17,6 +18,7 @@ import (
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/osquery/osquery-go/gen/osquery"
 	"github.com/osquery/osquery-go/plugin/logger"
+	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -258,6 +260,101 @@ func TestShutdownBasic(t *testing.T) {
 		}
 
 	}
+}
+
+// TestBufferedTransportFactory verifies that a server configured with a
+// buffering transport factory still parses incoming requests and returns
+// complete responses. The buffered transport only emits on Flush() or when
+// full, so this exercises that the generated processor flushes at each
+// response boundary in both directions.
+func TestBufferedTransportFactory(t *testing.T) {
+	t.Parallel()
+
+	tmp, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	sockPath := tmp.Name()
+	defer os.Remove(sockPath)
+
+	retUUID := osquery.ExtensionRouteUUID(0)
+	mock := &MockExtensionManager{
+		RegisterExtensionFunc: func(info *osquery.InternalExtensionInfo, registry osquery.ExtensionRegistry) (*osquery.ExtensionStatus, error) {
+			return &osquery.ExtensionStatus{Code: 0, UUID: retUUID}, nil
+		},
+		DeRegisterExtensionFunc: func(uuid osquery.ExtensionRouteUUID) (*osquery.ExtensionStatus, error) {
+			return &osquery.ExtensionStatus{}, nil
+		},
+		CloseFunc: func() {},
+	}
+
+	// Return enough rows that the response easily exceeds the buffer size,
+	// forcing intermediate flushes as the buffer fills as well as the final
+	// flush at the response boundary.
+	const numRows = 5000
+	gen := func(ctx context.Context, qc table.QueryContext) ([]map[string]string, error) {
+		rows := make([]map[string]string, 0, numRows)
+		for i := 0; i < numRows; i++ {
+			rows = append(rows, map[string]string{
+				"idx":  strconv.Itoa(i),
+				"data": strings.Repeat("x", 64),
+			})
+		}
+		return rows, nil
+	}
+
+	server := &ExtensionManagerServer{
+		serverClient: mock,
+		sockPath:     sockPath,
+		timeout:      defaultTimeout,
+		registry:     map[string](map[string]OsqueryPlugin){},
+		// Small buffer so the large response spans multiple buffer fills.
+		transportFactory: thrift.NewTBufferedTransportFactory(1024),
+	}
+	for reg := range validRegistryNames {
+		server.registry[reg] = make(map[string]OsqueryPlugin)
+	}
+	server.RegisterPlugin(table.NewPlugin("buffered_test", []table.ColumnDefinition{
+		table.TextColumn("idx"),
+		table.TextColumn("data"),
+	}, gen))
+
+	go func() {
+		// Serve may hang after shutdown in this harness; we only care that
+		// the request/response round-trips correctly.
+		_ = server.Start()
+	}()
+	defer server.Shutdown(context.Background())
+
+	server.waitStarted()
+
+	listenPath := fmt.Sprintf("%s.%d", sockPath, retUUID)
+	addr, err := net.ResolveUnixAddr("unix", listenPath)
+	require.NoError(t, err)
+
+	var sock *thrift.TSocket
+	opened := false
+	for attempt := 0; attempt < 10 && !opened; attempt++ {
+		sock = thrift.NewTSocketFromAddrTimeout(addr, 500*time.Millisecond, 500*time.Millisecond)
+		if err = sock.Open(); err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		opened = true
+	}
+	require.NoError(t, err)
+
+	client := osquery.NewExtensionManagerClientFactory(sock, thrift.NewTBinaryProtocolFactoryConf(nil))
+
+	resp, err := client.Call(context.Background(), "table", "buffered_test", osquery.ExtensionPluginRequest{
+		"action":  "generate",
+		"context": "{}",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Status)
+	require.Equal(t, int32(0), resp.Status.Code, resp.Status.Message)
+	require.Len(t, resp.Response, numRows)
+	require.Equal(t, "0", resp.Response[0]["idx"])
+	require.Equal(t, strings.Repeat("x", 64), resp.Response[0]["data"])
+	require.Equal(t, strconv.Itoa(numRows-1), resp.Response[numRows-1]["idx"])
 }
 
 func TestNewExtensionManagerServer(t *testing.T) {


### PR DESCRIPTION
This pull request enhances the `ExtensionManagerServer` to support configurable Thrift transport factories, allowing for buffered transport and improved performance with large result sets. It also adds a comprehensive test to verify correct behavior when using a buffered transport factory.

**Transport Factory Configuration:**

- Added a `transportFactory` field to the `ExtensionManagerServer` struct and a `WithTransportFactory` option, enabling the use of custom Thrift transport factories for the server. This allows switching from the default unbuffered transport to a buffered one, which can significantly reduce syscall overhead for large responses. [[1]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R64) [[2]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R121-R133)
- Updated the server startup logic in `Start()` to use the configured transport factory (or default to unbuffered if none is set), and switched to using `thrift.NewTSimpleServer4` to support the new transport factory and protocol configuration.

**Testing and Validation:**

- Added a new test, `TestBufferedTransportFactory`, which verifies that the server correctly handles large responses and flushes buffers as expected when using a buffered transport factory. The test registers a table plugin that returns thousands of rows, ensuring the response exceeds the buffer size and exercises both intermediate and final flushes.
- Updated imports in `server_test.go` to include required packages for the new test and table plugin usage. [[1]](diffhunk://#diff-53170cac6baf0bf02f3aaa3994259ea4cffaaf2498e768fb7e03cf9f752af96cR11) [[2]](diffhunk://#diff-53170cac6baf0bf02f3aaa3994259ea4cffaaf2498e768fb7e03cf9f752af96cR21)